### PR TITLE
Add 32 byte default rekey() to CipherState

### DIFF
--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
@@ -109,10 +109,6 @@ class AESGCMFallbackCipherState implements CipherState {
 	 */
 	private void setup(byte[] ad)
 	{
-		// Check for nonce wrap-around.
-		if (n == Long.MIN_VALUE)
-			throw new IllegalStateException("Nonce has wrapped around");
-		
 		// Format the counter/IV block.
 		iv[0] = 0;
 		iv[1] = 0;

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
@@ -110,7 +110,7 @@ class AESGCMFallbackCipherState implements CipherState {
 	private void setup(byte[] ad)
 	{
 		// Check for nonce wrap-around.
-		if (n == -1L)
+		if (n == Long.MIN_VALUE)
 			throw new IllegalStateException("Nonce has wrapped around");
 		
 		// Format the counter/IV block.
@@ -261,5 +261,10 @@ class AESGCMFallbackCipherState implements CipherState {
 	@Override
 	public void setNonce(long nonce) {
 		n = nonce;
+	}
+
+	@Override
+	public long getNonce() {
+		return n;
 	}
 }

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
@@ -169,10 +169,6 @@ class AESGCMOnCtrCipherState implements CipherState {
 	 */
 	private void setup(byte[] ad) throws InvalidKeyException, InvalidAlgorithmParameterException
 	{
-		// Check for nonce wrap-around.
-		if (n == Long.MIN_VALUE)
-			throw new IllegalStateException("Nonce has wrapped around");
-		
 		// Format the counter/IV block for AES/CTR/NoPadding.
 		iv[0] = 0;
 		iv[1] = 0;

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
@@ -170,7 +170,7 @@ class AESGCMOnCtrCipherState implements CipherState {
 	private void setup(byte[] ad) throws InvalidKeyException, InvalidAlgorithmParameterException
 	{
 		// Check for nonce wrap-around.
-		if (n == -1L)
+		if (n == Long.MIN_VALUE)
 			throw new IllegalStateException("Nonce has wrapped around");
 		
 		// Format the counter/IV block for AES/CTR/NoPadding.
@@ -331,5 +331,10 @@ class AESGCMOnCtrCipherState implements CipherState {
 	@Override
 	public void setNonce(long nonce) {
 		n = nonce;
+	}
+
+	@Override
+	public long getNonce() {
+		return n;
 	}
 }

--- a/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java
@@ -136,7 +136,7 @@ class ChaChaPolyCipherState implements CipherState {
 	 */
 	private void setup(byte[] ad)
 	{
-		if (n == -1L)
+		if (n == Long.MIN_VALUE)
 			throw new IllegalStateException("Nonce has wrapped around");
 		ChaChaCore.initIV(input, n++);
 		ChaChaCore.hash(output, input);
@@ -286,5 +286,10 @@ class ChaChaPolyCipherState implements CipherState {
 	@Override
 	public void setNonce(long nonce) {
 		n = nonce;
+	}
+
+	@Override
+	public long getNonce() {
+		return n;
 	}
 }

--- a/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java
@@ -136,8 +136,6 @@ class ChaChaPolyCipherState implements CipherState {
 	 */
 	private void setup(byte[] ad)
 	{
-		if (n == Long.MIN_VALUE)
-			throw new IllegalStateException("Nonce has wrapped around");
 		ChaChaCore.initIV(input, n++);
 		ChaChaCore.hash(output, input);
 		Arrays.fill(polyKey, (byte)0);

--- a/src/main/java/com/southernstorm/noise/protocol/NonceCheckCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/NonceCheckCipherState.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.southernstorm.noise.protocol;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.ShortBufferException;
+
+/**
+ * A CipherState implementation that checks
+ * the nonce not to be the reserved <code>rekey()</code>
+ * value on encrypt and decrypt.
+ */
+public final class NonceCheckCipherState implements CipherState {
+	private final CipherState delegate;
+
+	public NonceCheckCipherState(CipherState delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public String getCipherName() {
+		return delegate.getCipherName();
+	}
+
+	@Override
+	public int getKeyLength() {
+		return delegate.getKeyLength();
+	}
+	
+	@Override
+	public int getMACLength() {
+		return delegate.getMACLength();
+	}
+
+	@Override
+	public void initializeKey(byte[] key, int offset) {
+		delegate.initializeKey(key, offset);
+	}
+
+	@Override
+	public boolean hasKey() {
+		return delegate.hasKey();
+	}
+	
+	@Override
+	public int encryptWithAd(byte[] ad, byte[] plaintext, int plaintextOffset, byte[] ciphertext, int ciphertextOffset, int length) throws ShortBufferException {
+		// Check for nonce wrap-around.
+		if (getNonce() == -1L)
+			throw new IllegalStateException("Nonce has wrapped around");
+		
+		return delegate.encryptWithAd(ad, plaintext, plaintextOffset, ciphertext, ciphertextOffset, length);
+	}
+
+	@Override
+	public int decryptWithAd(byte[] ad, byte[] ciphertext, int ciphertextOffset, byte[] plaintext, int plaintextOffset, int length) throws ShortBufferException, BadPaddingException {
+		// Check for nonce wrap-around.
+		if (getNonce() == -1L)
+			throw new IllegalStateException("Nonce has wrapped around");
+		
+		return delegate.decryptWithAd(ad, ciphertext, ciphertextOffset, plaintext, plaintextOffset, length);
+	}
+
+	@Override
+	public CipherState fork(byte[] key, int offset) {
+		return delegate.fork(key, offset);
+	}
+	
+	@Override
+	public void setNonce(long nonce) {
+		delegate.setNonce(nonce);
+	}
+
+	@Override
+	public long getNonce() {
+       return delegate.getNonce();
+   }
+
+	@Override
+	public void rekey() throws ShortBufferException {
+       delegate.rekey();
+   }
+
+	@Override
+	public void destroy() {
+		delegate.destroy();
+	}
+}

--- a/src/main/java/com/southernstorm/noise/protocol/SymmetricState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/SymmetricState.java
@@ -277,7 +277,7 @@ class SymmetricState implements Destroyable {
 			try {
 				c1 = cipher.fork(k1, 0);
 				c2 = cipher.fork(k2, 0);
-				pair = new CipherStatePair(c1, c2);
+				pair = new CipherStatePair(new NonceCheckCipherState(c1), new NonceCheckCipherState(c2));
 			} finally {
 				if (c1 == null || c2 == null || pair == null) {
 					// Could not create some of the objects.  Clean up the others


### PR DESCRIPTION
Add the REKEY() function as specified by the Noise specification for 32 byte keys.

Patch also contains a related fix for nonce overflow check, which was -1, but the overflow actually happens at Long.MIN_VALUE which is Long.MAX_VALUE+1. -1 is actually 2^64-1, which is used for the above rekey() function.