### PR TITLE
Added Automatic-Module-Name to support discovery using JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,18 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.southerstorm.noise</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Allow library consumers to use JPMS on this project. 

Automatic-Module-Name enforces a consisted name on projects using the Java Platform Module System. Without impacting on projects not using the module path. Automatic-Module-Name does not enforce any encapsulation on this project. 

Future notice:
Project should be transitioned to using module-info.java with Java 11. This does enforce encapsulation on this project. This should only be done if the Java ecosystem has moves significantly to using Java 11. 
See #11 