### PR TITLE
Using Java 11 with JPMS.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,24 +15,29 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
         </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.southerstorm.noise {
+    requires java.xml.bind;
+
+    exports com.southernstorm.noise.crypto;
+    exports com.southernstorm.noise.protocol;
+
+}


### PR DESCRIPTION
- updated jaxb-api and junit.

This PR should only be accepted as if the Java ecosystem has significantly moves to Java 11.

TODOs
- Java 11 does support X25519, ChaCha20, ChaCha20-Poly1305
- eliminate dependence on jaxb-api for data type conversion 