### PR TITLE
Fix boundary check regression

### DIFF
--- a/src/main/java/com/southernstorm/noise/crypto/NewHope.java
+++ b/src/main/java/com/southernstorm/noise/crypto/NewHope.java
@@ -88,7 +88,8 @@ public class NewHope {
 	 * The send buffer must have space for at least NewHope.SENDABYTES bytes
 	 * starting at sendOffset.
 	 * 
-	 * @see sharedb(), shareda()
+	 * @see #sharedb(byte[], int, byte[], int, byte[], int)
+   * @see #shareda(byte[], int, byte[], int)
 	 */
 	public void keygen(byte[] send, int sendOffset)
 	{
@@ -147,7 +148,8 @@ public class NewHope {
 	 * The received buffer must have space for at least NewHope.SENDABYTES
 	 * bytes starting at receivedOffset.
 	 * 
-	 * @see shareda(), keygen()
+	 * @see #shareda(byte[], int, byte[], int)
+   * @see #keygen(byte[], int)
 	 */
 	public void sharedb(byte[] sharedkey, int sharedkeyOffset,
 						byte[] send, int sendOffset,
@@ -221,7 +223,8 @@ public class NewHope {
 	 * The received buffer must have space for at least NewHope.SENDBBYTES bytes
 	 * starting at receivedOffset.
 	 * 
-	 * @see shareda(), keygen()
+	 * @see #shareda(byte[], int, byte[], int)
+   * @see #keygen(byte[], int)
 	 */
 	public void shareda(byte[] sharedkey, int sharedkeyOffset,
 						byte[] received, int receivedOffset)

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
@@ -187,7 +187,7 @@ class AESGCMFallbackCipherState implements CipherState {
 		int space;
 		if (ciphertextOffset < 0 || ciphertextOffset > ciphertext.length)
 			throw new IllegalArgumentException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
+		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
 			throw new IllegalArgumentException();
 		space = ciphertext.length - ciphertextOffset;
 		if (!haskey) {
@@ -221,7 +221,7 @@ class AESGCMFallbackCipherState implements CipherState {
 			space = ciphertext.length - ciphertextOffset;
 		if (length > space)
 			throw new ShortBufferException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
+		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
 			throw new IllegalArgumentException();
 		space = plaintext.length - plaintextOffset;
 		if (!haskey) {

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMFallbackCipherState.java
@@ -187,7 +187,7 @@ class AESGCMFallbackCipherState implements CipherState {
 		int space;
 		if (ciphertextOffset < 0 || ciphertextOffset > ciphertext.length)
 			throw new IllegalArgumentException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
+    if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
 			throw new IllegalArgumentException();
 		space = ciphertext.length - ciphertextOffset;
 		if (!haskey) {

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
@@ -220,7 +220,7 @@ class AESGCMOnCtrCipherState implements CipherState {
 		int space;
 		if (ciphertextOffset < 0 || ciphertextOffset > ciphertext.length)
 			throw new IllegalArgumentException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
+		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
 			throw new IllegalArgumentException();
 		space = ciphertext.length - ciphertextOffset;
 		if (keySpec == null) {
@@ -269,7 +269,7 @@ class AESGCMOnCtrCipherState implements CipherState {
 			space = ciphertext.length - ciphertextOffset;
 		if (length > space)
 			throw new ShortBufferException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
+		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
 			throw new IllegalArgumentException();
 		space = plaintext.length - plaintextOffset;
 		if (keySpec == null) {

--- a/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/AESGCMOnCtrCipherState.java
@@ -220,7 +220,7 @@ class AESGCMOnCtrCipherState implements CipherState {
 		int space;
 		if (ciphertextOffset < 0 || ciphertextOffset > ciphertext.length)
 			throw new IllegalArgumentException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
+    if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
 			throw new IllegalArgumentException();
 		space = ciphertext.length - ciphertextOffset;
 		if (keySpec == null) {

--- a/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java
@@ -248,7 +248,7 @@ class ChaChaPolyCipherState implements CipherState {
 			space = ciphertext.length - ciphertextOffset;
 		if (length > space)
 			throw new ShortBufferException();
-		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > plaintext.length || (plaintext.length - plaintextOffset) < length)
+		if (length < 0 || plaintextOffset < 0 || plaintextOffset > plaintext.length || length > ciphertext.length || (ciphertext.length - ciphertextOffset) < length)
 			throw new IllegalArgumentException();
 		space = plaintext.length - plaintextOffset;
 		if (!haskey) {

--- a/src/test/java/com/southernstorm/noise/tests/UnitVectorTests.java
+++ b/src/test/java/com/southernstorm/noise/tests/UnitVectorTests.java
@@ -1,0 +1,22 @@
+package com.southernstorm.noise.tests;
+
+import java.io.InputStream;
+import java.net.URL;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class UnitVectorTests {
+
+  private static final String testVectorsCommit = "5d0a74760320e5486ced302e36ccad91606aac43";
+
+  @Test
+  void testBasicVector() throws Exception {
+    try (InputStream stream = new URL(
+        "https://raw.githubusercontent.com/rweather/noise-c/" + testVectorsCommit
+            + "/tests/vector/noise-c-basic.txt").openStream()) {
+      VectorTests vectorTests = new VectorTests();
+      vectorTests.processInputStream(stream);
+      Assert.assertEquals(vectorTests.getFailed(), 0);
+    }
+  }
+}


### PR DESCRIPTION
There is a regression bug introduced with latest boundary check fixes:
https://github.com/rweather/noise-java/blob/95fa4af798af088bc49b41972a18a27343edb537/src/main/java/com/southernstorm/noise/protocol/ChaChaPolyCipherState.java#L251

The `length` here may also include `mac` length and the check is not valid in this case. 

Added test vector indicates that problem 

Also fix 3 javadoc items which cause Javadoc errors 