### PR TITLE
Fix test-running issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,15 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/test/java/com/southernstorm/noise/tests/UnitVectorTests.java
+++ b/src/test/java/com/southernstorm/noise/tests/UnitVectorTests.java
@@ -3,14 +3,14 @@ package com.southernstorm.noise.tests;
 import java.io.InputStream;
 import java.net.URL;
 import org.junit.Assert;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class UnitVectorTests {
 
   private static final String testVectorsCommit = "5d0a74760320e5486ced302e36ccad91606aac43";
 
   @Test
-  void testBasicVector() throws Exception {
+  public void testBasicVector() throws Exception {
     try (InputStream stream = new URL(
         "https://raw.githubusercontent.com/rweather/noise-c/" + testVectorsCommit
             + "/tests/vector/noise-c-basic.txt").openStream()) {


### PR DESCRIPTION
Hello!

I bumped into a handful of problems trying to build a fresh checkout of this project with Maven. This pull requests addresses them via three changes:

1. It looks like `UnitVectorTests` is trying to use part of the JUnit API that's not included in the project's dependencies as declared in `pom.xml`. 226aff4d3e80d8955695bdfb066a70d3c3f6bd42 resolves the situation by making `testBasicVector` use the JUnit 4 facilities declared in `pom.xml`.
2. With the dependency issue ironed out, `mvn clean test` will build the project without issue, but won't actually run any tests. Updating to the latest version of `maven-surefire-plugin` in 76cbc067e1499d4a08e18aeb50c7d665ec65941d resolves that issue.
3. This one isn't a blocker, but it looks like `jaxb-api` is only used in tests; we can move that dependency to the `test` scope so the non-test artifact for this project doesn't depend on `jaxb-api`.

Cheers!