### PR TITLE
Add support for some pskN variants

### DIFF
--- a/src/main/java/com/southernstorm/noise/protocol/HandshakeState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/HandshakeState.java
@@ -552,10 +552,6 @@ public class HandshakeState implements Destroyable {
 			if (preSharedKeyForNoisePSK == null)
 				throw new IllegalStateException("Pre-shared key required");
 		}
-		if ((requirements & PSK_REQUIRED_NNPSK) != 0) {
-			if (preSharedKeyForNNpsk == null)
-				throw new IllegalStateException("Pre-shared key for NNpsk required");
-		}
 
 		// Hash the prologue value.
 		if (prologue != null)
@@ -564,7 +560,8 @@ public class HandshakeState implements Destroyable {
 			symmetric.mixHash(emptyPrologue, 0, 0);
 		
 		// Hash the pre-shared key into the chaining key and handshake hash.
-		if (preSharedKeyForNoisePSK != null)
+		// FIXME: AM: isNoisePsk needed to support NNpsk0 etc. Why? ;)
+		if (isNoisePsk && preSharedKeyForNoisePSK != null)
 			symmetric.mixPreSharedKey(preSharedKeyForNoisePSK);
 		
 		// Mix the pre-supplied public keys into the handshake hash.
@@ -955,7 +952,7 @@ public class HandshakeState implements Destroyable {
 
 					case Pattern.PSK:
 					{
-						symmetric.mixPreSharedKey(preSharedKeyForNNpsk);
+						symmetric.mixKeyAndHash(preSharedKeyForNoisePSK, 0, preSharedKeyForNoisePSK.length);
 					}
 					break;
 
@@ -1161,7 +1158,7 @@ public class HandshakeState implements Destroyable {
 					break;
 					case Pattern.PSK:
 					{
-						symmetric.mixPreSharedKey(preSharedKeyForNNpsk);
+						symmetric.mixKeyAndHash(preSharedKeyForNoisePSK, 0, preSharedKeyForNoisePSK.length);
 					}
 					break;
 
@@ -1276,8 +1273,6 @@ public class HandshakeState implements Destroyable {
 			fixedHybrid.destroy();
 		if (preSharedKeyForNoisePSK != null)
 			Noise.destroy(preSharedKeyForNoisePSK);
-		if (preSharedKeyForNNpsk != null)
-			Noise.destroy(preSharedKeyForNNpsk);
 		if (prologue != null)
 			Noise.destroy(prologue);
 	}

--- a/src/main/java/com/southernstorm/noise/protocol/HandshakeState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/HandshakeState.java
@@ -47,7 +47,7 @@ public class HandshakeState implements Destroyable {
 	private int requirements;
 	private short[] pattern;
 	private int patternIndex;
-	private byte[] preSharedKeyForNoisePSK;
+	private byte[] preSharedKey;
 	private byte[] prologue;
 	private boolean isNoisePsk;
 
@@ -251,7 +251,7 @@ public class HandshakeState implements Destroyable {
 	 */
 	public boolean needsPreSharedKey()
 	{
-		if (preSharedKeyForNoisePSK != null)
+		if (preSharedKey != null)
 			return false;
 		else
 			return (requirements & PSK_REQUIRED) != 0;
@@ -266,7 +266,7 @@ public class HandshakeState implements Destroyable {
 	 */
 	public boolean hasPreSharedKey()
 	{
-		return preSharedKeyForNoisePSK != null;
+		return preSharedKey != null;
 	}
 
 	/**
@@ -298,11 +298,11 @@ public class HandshakeState implements Destroyable {
 			throw new IllegalStateException
 				("Handshake has already started; cannot set pre-shared key");
 		}
-		if (preSharedKeyForNoisePSK != null) {
-			Noise.destroy(preSharedKeyForNoisePSK);
-			preSharedKeyForNoisePSK = null;
+		if (preSharedKey != null) {
+			Noise.destroy(preSharedKey);
+			preSharedKey = null;
 		}
-		preSharedKeyForNoisePSK = Noise.copySubArray(key, offset, length);
+		preSharedKey = Noise.copySubArray(key, offset, length);
 	}
 
 	/**
@@ -510,7 +510,7 @@ public class HandshakeState implements Destroyable {
 				throw new IllegalStateException("Remote static key required");
 		}
 		if ((requirements & PSK_REQUIRED) != 0) {
-			if (preSharedKeyForNoisePSK == null)
+			if (preSharedKey == null)
 				throw new IllegalStateException("Pre-shared key required");
 		}
 
@@ -522,9 +522,9 @@ public class HandshakeState implements Destroyable {
 		
 		// Hash the pre-shared key into the chaining key and handshake hash.
 		// FIXME: AM: isNoisePsk needed to support NNpsk0 etc. Why? ;)
-		if (isNoisePsk && preSharedKeyForNoisePSK != null)
-			symmetric.mixPreSharedKey(preSharedKeyForNoisePSK);
-		
+		if (isNoisePsk && preSharedKey != null)
+			symmetric.mixPreSharedKey(preSharedKey);
+
 		// Mix the pre-supplied public keys into the handshake hash.
 		if (isInitiator) {
 			if ((requirements & LOCAL_PREMSG) != 0)
@@ -533,7 +533,7 @@ public class HandshakeState implements Destroyable {
 				symmetric.mixPublicKey(remoteEphemeral);
 				if (remoteHybrid != null)
 					symmetric.mixPublicKey(remoteHybrid);
-				if (preSharedKeyForNoisePSK != null)
+				if (preSharedKey != null)
 					symmetric.mixPublicKeyIntoCK(remoteEphemeral);
 			}
 			if ((requirements & REMOTE_PREMSG) != 0)
@@ -545,7 +545,7 @@ public class HandshakeState implements Destroyable {
 				symmetric.mixPublicKey(localEphemeral);
 				if (localHybrid != null)
 					symmetric.mixPublicKey(localHybrid);
-				if (preSharedKeyForNoisePSK != null)
+				if (preSharedKey != null)
 					symmetric.mixPublicKeyIntoCK(localEphemeral);
 			}
 			if ((requirements & LOCAL_PREMSG) != 0)
@@ -818,7 +818,7 @@ public class HandshakeState implements Destroyable {
 
 						// If the protocol is using pre-shared keys, then also mix
 			            // the local ephemeral key into the chaining key.
-						if (preSharedKeyForNoisePSK != null)
+						if (preSharedKey != null)
 							symmetric.mixKey(message, messagePosn, len);
 						messagePosn += len;
 					}
@@ -913,7 +913,7 @@ public class HandshakeState implements Destroyable {
 
 					case Pattern.PSK:
 					{
-						symmetric.mixKeyAndHash(preSharedKeyForNoisePSK, 0, preSharedKeyForNoisePSK.length);
+						symmetric.mixKeyAndHash(preSharedKey, 0, preSharedKey.length);
 					}
 					break;
 
@@ -1023,7 +1023,7 @@ public class HandshakeState implements Destroyable {
 
 						// If the protocol is using pre-shared keys, then also mix
 			            // the remote ephemeral key into the chaining key.
-						if (preSharedKeyForNoisePSK != null)
+						if (preSharedKey != null)
 							symmetric.mixKey(message, messageOffset, len);
 						messageOffset += len;
 					}
@@ -1119,7 +1119,7 @@ public class HandshakeState implements Destroyable {
 					break;
 					case Pattern.PSK:
 					{
-						symmetric.mixKeyAndHash(preSharedKeyForNoisePSK, 0, preSharedKeyForNoisePSK.length);
+						symmetric.mixKeyAndHash(preSharedKey, 0, preSharedKey.length);
 					}
 					break;
 
@@ -1232,8 +1232,8 @@ public class HandshakeState implements Destroyable {
 			fixedEphemeral.destroy();
 		if (fixedHybrid != null)
 			fixedHybrid.destroy();
-		if (preSharedKeyForNoisePSK != null)
-			Noise.destroy(preSharedKeyForNoisePSK);
+		if (preSharedKey != null)
+			Noise.destroy(preSharedKey);
 		if (prologue != null)
 			Noise.destroy(prologue);
 	}

--- a/src/main/java/com/southernstorm/noise/protocol/Pattern.java
+++ b/src/main/java/com/southernstorm/noise/protocol/Pattern.java
@@ -38,6 +38,7 @@ class Pattern {
 	public static final short SS = 6;
 	public static final short F = 7;
 	public static final short FF = 8;
+	public static final short PSK = 9;
 	public static final short FLIP_DIR = 255;
 	
 	// Pattern flag bits.
@@ -91,6 +92,15 @@ class Pattern {
 	    FLAG_LOCAL_EPHEMERAL |
 	    FLAG_REMOTE_EPHEMERAL,
 
+	    E,
+	    FLIP_DIR,
+	    E,
+	    EE
+	};
+	private static final short[] noise_pattern_NNpsk0 = {
+	    FLAG_LOCAL_EPHEMERAL |
+	    FLAG_REMOTE_EPHEMERAL,
+		PSK,
 	    E,
 	    FLIP_DIR,
 	    E,
@@ -747,6 +757,8 @@ class Pattern {
 			return noise_pattern_X;
 		else if (name.equals("NN"))
 			return noise_pattern_NN;
+		else if (name.equals("NNpsk0"))
+			return noise_pattern_NNpsk0;
 		else if (name.equals("NK"))
 			return noise_pattern_NK;
 		else if (name.equals("NX"))

--- a/src/main/java/com/southernstorm/noise/protocol/Pattern.java
+++ b/src/main/java/com/southernstorm/noise/protocol/Pattern.java
@@ -54,6 +54,7 @@ class Pattern {
 	public static final short FLAG_REMOTE_EPHEM_REQ = 0x0800;
 	public static final short FLAG_REMOTE_HYBRID = 0x1000;
 	public static final short FLAG_REMOTE_HYBRID_REQ = 0x2000;
+	public static final short FLAG_PSK = 0x4000;
 
 	private static final short[] noise_pattern_N = {
 	    FLAG_LOCAL_EPHEMERAL |
@@ -92,15 +93,6 @@ class Pattern {
 	    FLAG_LOCAL_EPHEMERAL |
 	    FLAG_REMOTE_EPHEMERAL,
 
-	    E,
-	    FLIP_DIR,
-	    E,
-	    EE
-	};
-	private static final short[] noise_pattern_NNpsk0 = {
-	    FLAG_LOCAL_EPHEMERAL |
-	    FLAG_REMOTE_EPHEMERAL,
-		PSK,
 	    E,
 	    FLIP_DIR,
 	    E,
@@ -747,8 +739,52 @@ class Pattern {
 	 * @param name The name of the pattern.
 	 * @return The pattern description or null.
 	 */
-	public static short[] lookup(String name)
-	{
+	public static short[] lookup(String name) {
+		int pskIndex = pskModifier(name);
+		name = cutPsk(name);
+		short[] pattern = get(name);
+		pattern = insertPsk(pattern, pskIndex);
+		return pattern;
+	}
+
+	/**
+	 * Insert psk token if needed
+	 */
+	private static short[] insertPsk(short[] pattern, int pskIndex) {
+		if (pattern != null && pskIndex > -1) {
+			if (pskIndex != 0) {
+				int handshake = 0;
+				int pos = 1;
+				for (; pos < pattern.length; pos++) {
+					if (pattern[pos] == FLIP_DIR) {
+						handshake++;
+					}
+					if (handshake == pskIndex) {
+						break;
+					}
+				}
+				pskIndex = pos - 1;
+			}
+			pattern = insertPskTokenAt(pattern, pskIndex);
+			pattern[0] |= FLAG_PSK;
+		}
+		return pattern;
+	}
+
+	private static short[] insertPskTokenAt(short[] pattern, int pskIndex) {
+		short[] newPattern = new short[pattern.length + 1];
+		for (int pos = 0; pos <= pskIndex; pos++) {
+			newPattern[pos] = pattern[pos];
+		}
+		newPattern[pskIndex + 1] = PSK;
+		for (int pos = pskIndex + 1; pos < pattern.length; pos++) {
+			newPattern[pos + 1] = pattern[pos];
+		}
+		return newPattern;
+	}
+
+	private static short[] get(String name) {
+
 		if (name.equals("N"))
 			return noise_pattern_N;
 		else if (name.equals("K"))
@@ -757,8 +793,6 @@ class Pattern {
 			return noise_pattern_X;
 		else if (name.equals("NN"))
 			return noise_pattern_NN;
-		else if (name.equals("NNpsk0"))
-			return noise_pattern_NNpsk0;
 		else if (name.equals("NK"))
 			return noise_pattern_NK;
 		else if (name.equals("NX"))
@@ -832,6 +866,29 @@ class Pattern {
 		else if (name.equals("IXnoidh+hfs"))
 			return noise_pattern_IXnoidh_hfs;
 		return null;
+	}
+
+	private static String cutPsk(String name) {
+		int pos = name.indexOf("+psk");
+		if (pos > 0) {
+			return name.substring(0, pos) + name.substring(pos + 4);
+		}
+		pos = name.indexOf("psk");
+		if (pos > 0) {
+			return name.substring(0, pos) + name.substring(pos + 4);
+		}
+		return name;
+	}
+
+	/*
+	 * determine the psk modifier if used in pattern.
+	 */
+	private static int pskModifier(String name) {
+		int pos = name.indexOf("psk");
+		if (pos > -1) {
+			return Integer.parseInt(name.substring(pos + 3, pos + 4));
+		}
+		return -1;
 	}
 
 	/**

--- a/src/main/java/com/southernstorm/noise/protocol/SymmetricState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/SymmetricState.java
@@ -139,6 +139,7 @@ class SymmetricState implements Destroyable {
 	 * @param key The pre-shared key value.
 	 */
 	public void mixPreSharedKey(byte[] key)
+
 	{
 		byte[] temp = new byte [hash.getDigestLength()];
 		try {

--- a/src/main/java/com/southernstorm/noise/protocol/SymmetricState.java
+++ b/src/main/java/com/southernstorm/noise/protocol/SymmetricState.java
@@ -22,7 +22,7 @@
 
 package com.southernstorm.noise.protocol;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/src/test/java/com/southernstorm/noise/tests/ProtocolTest.java
+++ b/src/test/java/com/southernstorm/noise/tests/ProtocolTest.java
@@ -18,7 +18,7 @@ public class ProtocolTest {
         byte[] key = Base64.getDecoder().decode("LOaZwNhb6Ct5o5jRHIVQElRz4Lq25a4vEQ8TGTQT4hw=");
         assert key.length == 32;
 
-        client.setPreSharedKeyForNNpsk(key, 0, key.length);
+        client.setPreSharedKey(key, 0, key.length);
         byte[] prologue = "NoiseAPIInit\0\0".getBytes(StandardCharsets.US_ASCII);
         client.setPrologue(prologue, 0, prologue.length);
         client.start();

--- a/src/test/java/com/southernstorm/noise/tests/ProtocolTest.java
+++ b/src/test/java/com/southernstorm/noise/tests/ProtocolTest.java
@@ -1,0 +1,27 @@
+package com.southernstorm.noise.tests;
+
+import com.southernstorm.noise.protocol.HandshakeState;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ProtocolTest {
+    @Test
+    public void testCreateHandshakeState() throws NoSuchAlgorithmException {
+        HandshakeState client = new HandshakeState("Noise_NNpsk0_25519_ChaChaPoly_SHA256", HandshakeState.INITIATOR);
+        assertNotNull(client);
+
+        byte[] key = Base64.getDecoder().decode("LOaZwNhb6Ct5o5jRHIVQElRz4Lq25a4vEQ8TGTQT4hw=");
+        assert key.length == 32;
+
+        client.setPreSharedKeyForNNpsk(key, 0, key.length);
+        byte[] prologue = "NoiseAPIInit\0\0".getBytes(StandardCharsets.US_ASCII);
+        client.setPrologue(prologue, 0, prologue.length);
+        client.start();
+
+    }
+}

--- a/src/test/java/com/southernstorm/noise/tests/UnitVectorTests.java
+++ b/src/test/java/com/southernstorm/noise/tests/UnitVectorTests.java
@@ -16,7 +16,17 @@ public class UnitVectorTests {
             + "/tests/vector/noise-c-basic.txt").openStream()) {
       VectorTests vectorTests = new VectorTests();
       vectorTests.processInputStream(stream);
-      Assert.assertEquals(vectorTests.getFailed(), 0);
+      Assert.assertEquals(0, vectorTests.getFailed());
+    }
+  }
+
+  @Test
+  public void testCacophonyVector() throws Exception {
+    try (InputStream stream = new URL(
+            "https://raw.githubusercontent.com/centromere/cacophony/master/vectors/cacophony.txt").openStream()) {
+      VectorTests vectorTests = new VectorTests();
+      vectorTests.processInputStream(stream);
+      Assert.assertEquals(0, vectorTests.getFailed());
     }
   }
 }


### PR DESCRIPTION
ESPhome uses "Noise_NNpsk0_25519_ChaChaPoly_SHA256". This PR adds support for some pskN variants.

While tests for the needed variants work fine this still needs a review from someone that is more a crypto expert than I am. 

Are there chances to get this merged?